### PR TITLE
Fix 'fin latest' without version

### DIFF
--- a/functions/fin.fish
+++ b/functions/fin.fish
@@ -49,9 +49,11 @@ function fin
             set cmd "remove"
 
         case latest
-            set -e argv[1]
             set cmd "use"
-            set argv[1] "latest-$argv[1]"
+            if set -q argv[2]
+                set -e argv[1]
+                set argv[1] "latest-$argv[1]"
+            end
 
         case -\*\*
             echo "fin: '$argv[1]' is not a valid option." > /dev/stderr


### PR DESCRIPTION
Otherwise we end up with:

```
~ fin latest
fin: It seems 'latest-' is not a valid version number.

Hint: Examples of valid node versions:
       v5.10.1
        latest
          0.12
           lts
```
