### PR TITLE
Remove current active version if any when calling "rm" without arg

### DIFF
--- a/functions/fin.fish
+++ b/functions/fin.fish
@@ -47,6 +47,10 @@ function fin
         case r rm remove
             set -e argv[1]
             set cmd "remove"
+            if not set -q argv[1] and test -s "$fin_config/version"
+                read -l version_current < "$fin_config/version"
+                set argv[1] $version_current
+            end
 
         case latest
             set -e argv[1]


### PR DESCRIPTION
Also tempted to suggest alias "activate/deactivate", because I feel like "fin deactivate" would be more intuitive than "fin rm", but YMMV ;)
