### PR TITLE
Attempt to fix error message with .node-version file.

### DIFF
--- a/functions/__fnm_run_bin_as.fish
+++ b/functions/__fnm_run_bin_as.fish
@@ -30,18 +30,11 @@ function __fnm_run_bin_as -a name
     set -l rc_ver
     set -l sel_ver
 
-    if set rc_ver (__fnm_read_fnmrc)
-        if test -s "$fnm_config/version"
-            read sel_ver < "$fnm_config/version"
-        end
-
-        if not fnm "$rc_ver"
-            return 1
-        end
-
-        if test -s "$fnm_config/version"
-            read rc_ver < "$fnm_config/version"
-        end
+    if set rc_ver (__fnm_read_fnmrc) and not fnm "$rc_ver"
+        return 1
+    else if test -s "$fnm_config/version" 
+        read sel_ver < "$fnm_config/version"
+        read rc_ver < "$fnm_config/version"
     end
 
     set -lx PATH $PATH

--- a/functions/__fnm_run_bin_as.fish
+++ b/functions/__fnm_run_bin_as.fish
@@ -39,7 +39,9 @@ function __fnm_run_bin_as -a name
             return 1
         end
 
-        read rc_ver < "$fnm_config/version"
+        if test -s "$fnm_config/version"
+            read rc_ver < "$fnm_config/version"
+        end
     end
 
     set -lx PATH $PATH


### PR DESCRIPTION
Fixes #48 

I'm not sure this is the right way to go about it, but it removes the error locally. Should it even be getting to this point? It looks like it's overwriting the `rc_ver` variable _if_ a `.node-version` (or similar) file exists.