### PR TITLE
Normalize cursor with tput

### DIFF
--- a/functions/fnm.fish
+++ b/functions/fnm.fish
@@ -127,4 +127,7 @@ function fnm -d "node.js version manager"
     complete -c fnm --erase
 
     source "$config_home/fish/completions/fnm.fish" ^ /dev/null
+
+    tput cvvis
 end
+


### PR DESCRIPTION
While using `fnm` (with fish 2.7.1 + tmux), I constantly encountered an issue resembling the one described in #32.

`tput cvvis` worked for me, so to be on the safe side I've added this statement in the end of the main `fnm` function. Worked like a charm.

I think that it won't affect users that _don't_ have this problem, so this extra statement won't harm them.