### PR TITLE
Remove existing npm before copying activated version

### DIFF
--- a/functions/__fnm_use.fish
+++ b/functions/__fnm_use.fish
@@ -71,6 +71,12 @@ function __fnm_use -a v
         return 1
     end
 
+    if test -d "$fnm_cache/versions/$v/lib/node_modules/npm"
+        if test -d "$fnm_config/lib/node_modules/npm"
+            command rm -rf "$fnm_config/lib/node_modules/npm"
+        end
+    end
+
     command cp -fR "$fnm_cache/versions/$v/lib/." "$fnm_config/lib"
 
     echo "$v" > "$fnm_config/version"


### PR DESCRIPTION
## Issue

See [npm.community](https://npm.community/t/asyncwrite-is-not-a-function-at-node-10-3-0-and-npm-6-1-0/193/14) and tj/n#510, or search for issues related to:
```bash
npm ERR! asyncWrite is not a function
npm ERR! pna.nextTick is not a function
```

## Solution

Remove the existing version before copying the new one as tj/n#470.