### PR TITLE
Support lts/*

### DIFF
--- a/functions/__fnm_read_fnmrc.fish
+++ b/functions/__fnm_read_fnmrc.fish
@@ -14,5 +14,9 @@ function __fnm_read_fnmrc
 
     read -l v < "$fnmrc"
 
+    if test "$v" = "lts/*"
+        set v "lts"
+    end
+
     printf "%s\n" $v
 end


### PR DESCRIPTION
Related #60.
 
@jorgebucaran As it's very specific to reading values from `.nvmrc`, I added a quick check here.