### PR TITLE
feat(node): use local node binary if existing

### DIFF
--- a/functions/node.fish
+++ b/functions/node.fish
@@ -1,3 +1,7 @@
 function node -d "Server-side JavaScript runtime" -w node
-    __fnm_run_bin_as "node" $argv
+    if test -e "node_modules/.bin/node"
+        node_modules/.bin/node $argv
+    else
+        __fnm_run_bin_as "node" $argv
+    end
 end


### PR DESCRIPTION
Useful when node is installed as a dependency in the `package.json`.