### PR TITLE
Fixed unexisting repositories

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,4 +1,4 @@
-fisherman/menu
-fisherman/get_file_age
-fisherman/await
-fisherman/last_job_id
+fishpkg/fish-menu
+fishpkg/fish-get-file-age
+fishpkg/fish-await
+fishpkg/fish-last-job-id


### PR DESCRIPTION
This will fix the currently broken install on a fresh machine.

Currently the install prints this at the end:

```
fetching https://codeload.github.com/fisherman/menu/tar.gz/master
fetching https://codeload.github.com/fisherman/get_file_age/tar.gz/master
fetching https://codeload.github.com/fisherman/await/tar.gz/master
fetching https://codeload.github.com/fisherman/last_job_id/tar.gz/master
cannot add github.com/fisherman/get_file_age -- is this a valid package?
cannot add github.com/fisherman/last_job_id -- is this a valid package?
cannot add github.com/fisherman/menu -- is this a valid package?
cannot add github.com/fisherman/await -- is this a valid package?
```

The "fisherman" GitHub user removed all his repositories...