### PR TITLE
Use a single symlink that always points to the nodejs version being used

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -195,7 +195,7 @@ function _nvm_use
 
     echo $ver >$nvm_config/version
 
-    ln -sfn "$nvm_config/current" "$nvm_config/$ver"
+    ln -sfn "$nvm_config/$ver" "$nvm_config/current"
 
     if not contains -- "$nvm_config/current/bin" $fish_user_paths
         set -U fish_user_paths "$nvm_config/current/bin" $fish_user_paths

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -189,21 +189,16 @@ function _nvm_use
         command mv -f $nvm_config/$ver. $target
     end
 
-    if test -s "$nvm_config/version"
-        read -l last <"$nvm_config/version"
-        if set -l i (contains -i -- "$nvm_config/$last/bin" $fish_user_paths)
-            set -e fish_user_paths[$i]
-        end
-    end
-
     if set -l root (_nvm_find_up (pwd) $nvm_file)
         echo $argv[1] >$root/$nvm_file
     end
 
     echo $ver >$nvm_config/version
 
-    if not contains -- "$nvm_config/$ver/bin" $fish_user_paths
-        set -U fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
+    ln -sfn "$nvm_config/current" "$nvm_config/$ver"
+
+    if not contains -- "$nvm_config/current/bin" $fish_user_paths
+        set -U fish_user_paths "$nvm_config/current/bin" $fish_user_paths
     end
 end
 


### PR DESCRIPTION
I find that it's useful:

1. In places you are not in fish shell but you still need to access the nodejs bin dir. Otherwise you need to do some gymnastics with the getting the version file and constructing the path. 
1. Places you need to hardcode a path but you still want to point to the nodejs bin you are using day to day and not update it every time you start using a new version.
1. A bit simpler than cleaning fish_user_paths from previous paths every time you change version

I don't mind this not being merged. Just opening for clarity.

**Edit** : closed primarily due to lack of motivation as @jorgebucaran didn't hint his intentions and was acting agressive