### PR TITLE
Replace usage of fish_user_paths with symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Download and switch to the latest Node.js release.
 nvm use latest
 ```
 
-> **Note:** This downloads the latest Node.js release tarball from the [official mirror](https://nodejs.org/dist), extracts it to <code>[\$XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)/nvm</code> and modifies your `$PATH` so it can be used immediately. Learn more about the Node.js release schedule [here](https://github.com/nodejs/Release).
+> **Note:** This downloads the latest Node.js release tarball from the [official mirror](https://nodejs.org/dist), extracts it to <code>[\$XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)/nvm</code> and let's you use it immediately in all your open shells. Learn more about the Node.js release schedule [here](https://github.com/nodejs/Release).
 
 Download and switch to the latest LTS (long-term support) Node.js release.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Download and switch to the latest Node.js release.
 nvm use latest
 ```
 
-> **Note:** This downloads the latest Node.js release tarball from the [official mirror](https://nodejs.org/dist), extracts it to <code>[\$XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)/nvm</code> and let's you use it immediately in all your open shells. Learn more about the Node.js release schedule [here](https://github.com/nodejs/Release).
+> **Note:** This downloads the latest Node.js release tarball from the [official mirror](https://nodejs.org/dist), extracts it to <code>[\$XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)/nvm</code> and lets you use it immediately in all your open shells. Learn more about the Node.js release schedule [here](https://github.com/nodejs/Release).
 
 Download and switch to the latest LTS (long-term support) Node.js release.
 

--- a/conf.d/nvm.fish
+++ b/conf.d/nvm.fish
@@ -7,7 +7,6 @@ end
 
 function _nvm_uninstall -e nvm_uninstall
     if test -s "$nvm_config/version"
-        read -l ver <$nvm_config/version
         command rm -f $nvm_config/version
     end
 

--- a/conf.d/nvm.fish
+++ b/conf.d/nvm.fish
@@ -1,9 +1,13 @@
+set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME ~/.config
+set -g nvm_bin_path $XDG_CONFIG_HOME/nvm/bin
+
+if not contains $nvm_bin_path $PATH
+    set PATH $nvm_bin_path $PATH
+end
+
 function _nvm_uninstall -e nvm_uninstall
     if test -s "$nvm_config/version"
         read -l ver <$nvm_config/version
-        if set -l i (contains -i -- "$nvm_config/$ver/bin" $fish_user_paths)
-            set -e fish_user_paths[$i]
-        end
         command rm -f $nvm_config/version
     end
 

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -1,7 +1,6 @@
 set -g nvm_version 1.0.1
 
 function nvm -a cmd -d "Node.js version manager"
-    set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME ~/.config
     set -g nvm_config $XDG_CONFIG_HOME/nvm
     set -g nvm_file .nvmrc
     set -q nvm_mirror; or set -g nvm_mirror "https://nodejs.org/dist"

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -10,6 +10,10 @@ function nvm -a cmd -d "Node.js version manager"
         command mkdir -p $nvm_config
     end
 
+    if test ! -d $nvm_bin_path
+        command mkdir -p $nvm_bin_path
+    end
+
     switch "$cmd"
         case ls list
             set -e argv[1]
@@ -49,7 +53,7 @@ function _nvm_help
     echo "usage: nvm --help           Show this help"
     echo "       nvm --version        Show the current version of nvm"
     echo "       nvm ls [<regex>]     List available versions matching <regex>"
-    echo "       nvm use <version>    Download <version> and modify PATH to use it"
+    echo "       nvm use <version>    Download <version> and modify symlink to use it"
     echo "       nvm                  Use version in .nvmrc (or stdin if not a tty)"
     echo "examples:"
     echo "       nvm use 12"
@@ -189,21 +193,20 @@ function _nvm_use
         command mv -f $nvm_config/$ver. $target
     end
 
-    if test -s "$nvm_config/version"
-        read -l last <"$nvm_config/version"
-        if set -l i (contains -i -- "$nvm_config/$last/bin" $fish_user_paths)
-            set -e fish_user_paths[$i]
-        end
-    end
-
     if set -l root (_nvm_find_up (pwd) $nvm_file)
         echo $argv[1] >$root/$nvm_file
     end
 
     echo $ver >$nvm_config/version
 
-    if not contains -- "$nvm_config/$ver/bin" $fish_user_paths
-        set -U fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
+    if test -s $nvm_config/$ver/bin/node
+        ln -sf $nvm_config/$ver/bin/node $nvm_bin_path/node
+    end
+    if test -s $nvm_config/$ver/bin/npm
+        ln -sf $nvm_config/$ver/bin/npm $nvm_bin_path/npm
+    end
+    if test -s $nvm_config/$ver/bin/npx
+        ln -sf $nvm_config/$ver/bin/npx $nvm_bin_path/npx
     end
 end
 

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -1,6 +1,7 @@
 set -g nvm_version 1.0.1
 
 function nvm -a cmd -d "Node.js version manager"
+    set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME ~/.config
     set -g nvm_config $XDG_CONFIG_HOME/nvm
     set -g nvm_file .nvmrc
     set -q nvm_mirror; or set -g nvm_mirror "https://nodejs.org/dist"


### PR DESCRIPTION
fish_user_paths has the unfortunate side effect that if it points
to a path somewhere in the user's home directory, the path will be
set to the full path (i.e. /home/username/ instead of ~/) inside
the fish_variables file.

This is unfortunate because a user that wish to share the
fish_variables file between multiple computers, to get a unified
shell setup, it's not possible since the path will point to a home
directory that might not be the same between the host (since the
user possibly has different usernames on different hosts).

This aims to rememdy this by using symlinks instead of
the fish_user_paths variable.

/fixes #93 
