### PR TITLE
Fix error on use

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -203,7 +203,7 @@ function _nvm_use
     echo $ver >$nvm_config/version
 
     if not contains -- "$nvm_config/$ver/bin" $fish_user_paths
-        set -U fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
+        set -g fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
     end
 end
 


### PR DESCRIPTION
When I tried to `nvm use lts`, path was not updated, because:
```
set: Universal variable 'fish_user_paths' is shadowed by the global variable of the same name.
```
