### PR TITLE
[bugfix] unable to use npm.taobao.org as a mirror

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -189,7 +189,7 @@ function _nvm_use
         echo "fetching $url" >&2
         command mkdir -p $target/$name
 
-        if not command curl --fail --progress-bar $url.tar.gz | command tar -xzf- -C $target/$name
+        if not command curl -L --fail --progress-bar $url.tar.gz | command tar -xzf- -C $target/$name
             command rm -rf $target
             echo "nvm: fetch error -- are you offline?" >&2
             return 1


### PR DESCRIPTION
To fix following error when use npm.taobao.org:
```
fetching https://npm.taobao.org/mirrors/node/v10.20.1/node-v10.20.1-linux-x64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   183  100   183    0     0   1129      0 --:--:-- --:--:-- --:--:--  1129

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
nvm: fetch error -- are you offline?
```
