### PR TITLE
set -g fish_user_paths

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -217,7 +217,7 @@ function _nvm_use
     echo $ver >$nvm_config/version
 
     if not contains -- "$nvm_config/$ver/bin" $fish_user_paths
-        set -U fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
+        set -g fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
     end
 end
 


### PR DESCRIPTION
I think `set -g fish_user_paths` is better than `-U` option.  Although the official fish shell document points out the easiest way to export PATH is run `set -U fish_user_paths` once, this command do add `fish_user_paths` variable in the `fish_variables` file, and the content is url encoded, which is not human readable.

When using dotfile sync/backup tools like git or mackup, it's more practical to make the command versioned in some dotfile.
so I think `set -g fish_user_path` in the `config.fish` is more appreciated. since you can do more verbose and humanly like the following:
```
# brew
set -g fish_user_paths "/usr/local/sbin" $fish_user_paths
# python3.7
set -g fish_user_paths "$HOME/Library/Python/3.7/bin" $fish_user_paths
# composer
set -g fish_user_paths "$HOME/.composer/vendor/bin" $fish_user_paths
```

But if `nvm.fish` tries to `set -U fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths`, then the following error accurs:
```set: Universal variable 'fish_user_paths' is shadowed by the global variable of the same name.```