### PR TITLE
functions: nvm.fish: don't attempt to overwrite $fish_user_paths

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -217,7 +217,7 @@ function _nvm_use
     echo $ver >$nvm_config/version
 
     if not contains -- "$nvm_config/$ver/bin" $fish_user_paths
-        set -U fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
+        set fish_user_paths "$nvm_config/$ver/bin" $fish_user_paths
     end
 end
 


### PR DESCRIPTION
$fish_user_paths is set by the shell at startup, and should not be
overwritten with the -U flag. Doing so results in an error.

Instead, drop the -U flag, and simply append the NVM version bin to the
end of the user's $fish_user_paths.