### PR TITLE
Require 'os' in _nvm_node_info for older nodes

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -195,6 +195,7 @@ function _nvm_node_info
     set --local npm_path (string replace bin/npm-cli.js "" (realpath (command --search npm)))
     test -f $npm_path/package.json || set --local npm_version_default (command npm --version)
     command node --eval "
+        os = require('os')
         console.log(process.version)
         console.log('$npm_version_default' ? '$npm_version_default': require('$npm_path/package.json').version)
         console.log(process.execPath.replace(os.homedir(), '~'))


### PR DESCRIPTION
Older nodes (e.g. node 4), error out when calling `_nvm_node_info`, since `os` isn't imported by default. Requiring it makes sure it's around.