### PR TITLE
Add musl support

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -73,6 +73,13 @@ function nvm --argument-names cmd v --description "Node version manager"
                     case armv8 armv8l aarch64
                         set arch arm64
                 end
+                
+                # Set musl libc (https://github.com/nvm-sh/nvm/issues/1102#issuecomment-550572252)
+                # Requires setting unofficial mirror 
+                # set -U nvm_mirror https://unofficial-builds.nodejs.org/download/release/
+                if ldd (which echo) | grep -q musl
+                  set arch "$arch-musl"
+                end
 
                 set --local dir "node-$v-$os-$arch"
                 set --local url $nvm_mirror/$v/$dir.$ext


### PR DESCRIPTION
On alpine linux the installed version of node won't execute because its built with libc not musl.

## Test

1. Create a Dockerfile with the following steps and run `docker build .` you will see an error (screenshot).
2. Make change and try again you will see error related invalid mirror or host, but then the second command will succeed.

**NOTE: 

```dockerfile
FROM alpine

# Setup
RUN apk update && \
    apk add ca-certificates fish curl

SHELL ["/usr/bin/fish", "--login", "-c"]

RUN curl -sL https://git.io/fisher | source && \
    fisher install jorgebucaran/fisher && \
    fisher install jorgebucaran/nvm.fish 

# Try install node
RUN nvm install 14 && nvm uninstall 14

# Set the unoffical builds mirror (supports musl) and install
# Version 16 does not support musl yet
RUN set -U nvm_mirror https://unofficial-builds.nodejs.org/download/release && \
    nvm install 14
```
![image](https://user-images.githubusercontent.com/46549/115637877-12595200-a2c6-11eb-9ac1-bbb60a8f5980.png)

## Proof
![image](https://user-images.githubusercontent.com/46549/115637970-4a609500-a2c6-11eb-8dce-b38c2c230eb5.png)