### PR TITLE
Use darwin-arm64 binary when version above v16

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -63,7 +63,8 @@ function nvm --argument-names cmd v --description "Node version manager"
                     case x86_64
                         set arch x64
                     case arm64
-                        if test "$os" = darwin
+                        string match --regex --quiet "v(?<major>\d+)" $v
+                        if test "$os" = darwin -a $major -lt 16
                             set arch x64
                         end
                     case armv6 armv6l


### PR DESCRIPTION
Node.js v16.0.0 will be the first release to ship prebuilt binaries for Apple Silicon. This commit modifies the logic to keep darwin-x64 binaries for older versions but use darwin-arm64 for v16 or higher. Fixes #158.