### PR TITLE
Gracefully handle npm not being installed

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -196,11 +196,22 @@ function _nvm_current
 end
 
 function _nvm_node_info
-    set --local npm_path (string replace bin/npm-cli.js "" (realpath (command --search npm)))
-    test -f $npm_path/package.json || set --local npm_version_default (command npm --version)
+    set --local npm_path (command --search npm)
+    set --local npm_version "- not installed"
+
+    if test $npm_path
+        set --local npm_path (string replace bin/npm-cli.js "" (realpath $npm_path))
+
+        if test -f $npm_path/package.json
+            set --local npm_version_default (command npm --version)
+        else
+            set --local npm_version_default command node --eval "require('$npm_path/package.json').version"
+        end
+    end
+
     command node --eval "
         console.log(process.version)
-        console.log('$npm_version_default' ? '$npm_version_default': require('$npm_path/package.json').version)
+        console.log('$npm_version')
         console.log(process.execPath.replace(require('os').homedir(), '~'))
     "
 end

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -200,12 +200,12 @@ function _nvm_node_info
     set --local npm_version "- not installed"
 
     if test $npm_path
-        set --local npm_path (string replace bin/npm-cli.js "" (realpath $npm_path))
+        set npm_path (string replace bin/npm-cli.js "" (realpath $npm_path))
 
         if test -f $npm_path/package.json
-            set --local npm_version_default (command npm --version)
+            set npm_version (command npm --version)
         else
-            set --local npm_version_default command node --eval "require('$npm_path/package.json').version"
+            set npm_version command node --eval "require('$npm_path/package.json').version"
         end
     end
 


### PR DESCRIPTION
Previous behavior:

```fish
> nvm use system
realpath: missing operand
Try 'realpath --help' for more information.
internal/modules/cjs/loader.js:818
  throw err;
  ^

Error: Cannot find module '/package.json'
Require stack:
- /home/eugene/.config/fish/[eval]
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at [eval]:3:30
    at Script.runInThisContext (vm.js:120:18)
    at Object.runInThisContext (vm.js:309:38)
    at Object.<anonymous> ([eval]-wrapper:10:26)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at evalScript (internal/process/execution.js:94:25) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/home/eugene/.config/fish/[eval]' ]
}
Now using Node v12.22.5 (npm )
```

Now, we'll simply list that it is not installed:

```fish
> nvm use system
Now using Node v12.22.5 (npm - not installed) /usr/bin/node
```