### PR TITLE
Create index dir if not present on _nvm_index_update

### DIFF
--- a/functions/_nvm_index_update.fish
+++ b/functions/_nvm_index_update.fish
@@ -1,4 +1,11 @@
 function _nvm_index_update --argument-names mirror index
+    set --local index_dir (dirname $index)
+    set --local index_dir_present (test -f $index_dir)
+
+    if not test "$index_dir_present"
+        mkdir -p $index_dir
+    end
+
     if not command curl --location --silent $mirror/index.tab >$index.temp
         command rm -f $index.temp
         echo "nvm: Can't update index, host unvailable: \"$mirror\"" >&2


### PR DESCRIPTION
```fish
> nvm install lts
<W> fish: An error occurred while redirecting file '/home/eugene/.local/share/nvm/.index.temp'
open: No such file or directory
nvm: Can't update index, host unvailable: "https://nodejs.org/dist"
```

If the $index path does not exist in `_nvm_index_update`, it shows an error about not being able to update the index because the host is unavailable. However, really, it is because that index directory path is missing.

```fish
> nvm install lts
Installing Node v16.14.0 lts/gallium
Fetching https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.gz
Now using Node v16.14.0 (npm - not installed) ~/.local/share/nvm/v16.14.0/bin/node
```