### PR TITLE
Faster _nvm_find_up via string builtin

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -184,8 +184,8 @@ end
 
 function _nvm_find_up --argument-names path file
     test -e "$path/$file" && echo $path/$file || begin
-        test "$path" != / || return
-        _nvm_find_up (command dirname $path) $file
+        test ! -z "$path" || return
+        _nvm_find_up (string replace --regex -- '/[^/]*$' "" $path) $file
     end
 end
 


### PR DESCRIPTION
We could improve our .nvmrc find-up recursive function by switching to the `string` builtin instead of using `dirname`. 

![名称未設定](https://user-images.githubusercontent.com/56996/172690085-50a56f22-92db-4f1a-86f9-6c49e023a05b.png)

