### PR TITLE
Added function to symlink existing packages to nvm.fish

### DIFF
--- a/conf.d/nvm.fish
+++ b/conf.d/nvm.fish
@@ -6,6 +6,7 @@ function _nvm_install --on-event nvm_install
     test ! -d $nvm_data && command mkdir -p $nvm_data
     echo "Downloading the Node distribution index..." 2>/dev/null
     _nvm_index_update
+    _nvm_symlink_local
 end
 
 function _nvm_update --on-event nvm_update

--- a/functions/_nvm_symlink_local.fish
+++ b/functions/_nvm_symlink_local.fish
@@ -1,0 +1,17 @@
+function _nvm_symlink_local
+
+    test ! -d $nvm_data && command mkdir -p $nvm_data
+
+    set --local existingVersionsDir $HOME/.nvm/versions/node
+
+    if test -d $existingVersionsDir
+        echo "Found existing node packages at $existingVersionsDir" >&2
+        echo "Creating symlink to existing packages" >&2
+        command ln -sf $existingVersionsDir/* $nvm_data
+        echo "Found and linked:" >&2
+        _nvm_list 
+    else
+        echo "No exisiting NVM Node package found. Skipping..." >&2
+    end
+
+end


### PR DESCRIPTION
This request adds another step to the installation of the plugin by checking for existing Node Release (if available) and creating a symlink from them to the `nvm.fish` package directory.

This is mainly useful when an existing NVM installation exists on the previous shell before `fish` is installed.

There is a function available `_nvm_symlink_local` which can also be used on request. 