### PR TITLE
Invoke curl without using user's ~/.curlrc config

### DIFF
--- a/functions/_nvm_index_update.fish
+++ b/functions/_nvm_index_update.fish
@@ -3,7 +3,7 @@ function _nvm_index_update
 
     set --local index $nvm_data/.index
 
-    if not command curl --disable --location --silent $nvm_mirror/index.tab >$index.temp
+    if not command curl -q --location --silent $nvm_mirror/index.tab >$index.temp
         command rm -f $index.temp
         echo "nvm: Can't update index, host unavailable: \"$nvm_mirror\"" >&2
         return 1

--- a/functions/_nvm_index_update.fish
+++ b/functions/_nvm_index_update.fish
@@ -3,7 +3,7 @@ function _nvm_index_update
 
     set --local index $nvm_data/.index
 
-    if not command curl --location --silent $nvm_mirror/index.tab >$index.temp
+    if not command curl --disable --location --silent $nvm_mirror/index.tab >$index.temp
         command rm -f $index.temp
         echo "nvm: Can't update index, host unavailable: \"$nvm_mirror\"" >&2
         return 1

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -113,7 +113,7 @@ function nvm --description "Node version manager"
                     echo -e "Fetching \x1b[4m$url\x1b[24m\x1b[7m"
                 end
 
-                if ! command curl $silent --progress-bar --location $url |
+                if ! command curl --disable $silent --progress-bar --location $url |
                         command tar --extract --gzip --directory $nvm_data/$ver 2>/dev/null
                     command rm -rf $nvm_data/$ver
                     echo -e "\033[F\33[2K\x1b[0mnvm: Invalid mirror or host unavailable: \"$url\"" >&2

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -113,7 +113,7 @@ function nvm --description "Node version manager"
                     echo -e "Fetching \x1b[4m$url\x1b[24m\x1b[7m"
                 end
 
-                if ! command curl --disable $silent --progress-bar --location $url |
+                if ! command curl -q $silent --progress-bar --location $url |
                         command tar --extract --gzip --directory $nvm_data/$ver 2>/dev/null
                     command rm -rf $nvm_data/$ver
                     echo -e "\033[F\33[2K\x1b[0mnvm: Invalid mirror or host unavailable: \"$url\"" >&2


### PR DESCRIPTION
The idea is that a `~/.curlrc` can contain options that change the output, like `-w`, which can cause downstream tooling (like `tar`) to fail.

In this case, we want `curl` to behave consistently regardless of how the user has configured curl.

Fixes https://github.com/jorgebucaran/nvm.fish/issues/223
