### PR TITLE
Fix regex pattern in _nvm_list to correctly match version directory names

### DIFF
--- a/functions/_nvm_list.fish
+++ b/functions/_nvm_list.fish
@@ -1,9 +1,8 @@
 function _nvm_list
-    set --local versions $nvm_data/*
-    set --local installed_versions (string replace -a -- $nvm_data/ "" $versions)
+    set --local versions (string replace --all -- $nvm_data/ "" $nvm_data/*)
 
     set --query versions[1] &&
-        string match --entire --regex -- (string match --regex -- "v\d.+" $installed_versions |
+        string match --entire --regex -- (string match --regex -- "v\d.+" $versions |
             string escape --style=regex |
             string join "|"
         ) <$nvm_data/.index

--- a/functions/_nvm_list.fish
+++ b/functions/_nvm_list.fish
@@ -1,7 +1,8 @@
 function _nvm_list
     set --local versions $nvm_data/*
     set --query versions[1] &&
-        string match --entire --regex -- (string match --regex -- "v\d.+" $versions |
+        string match --entire --regex -- (string match --regex -- "/v\d.+" $versions |
+            string replace --regex -- "^/" "" |
             string escape --style=regex |
             string join "|"
         ) <$nvm_data/.index

--- a/functions/_nvm_list.fish
+++ b/functions/_nvm_list.fish
@@ -1,8 +1,9 @@
 function _nvm_list
     set --local versions $nvm_data/*
+    set --local installed_versions (string replace -a -- $nvm_data/ "" $versions)
+
     set --query versions[1] &&
-        string match --entire --regex -- (string match --regex -- "/v\d.+" $versions |
-            string replace --regex -- "^/" "" |
+        string match --entire --regex -- (string match --regex -- "v\d.+" $installed_versions |
             string escape --style=regex |
             string join "|"
         ) <$nvm_data/.index


### PR DESCRIPTION
**Description:**

This PR fixes an issue with the `_nvm_list` function where the regular expression pattern `"v\d.+"` was too broad and could match usernames that contain a `v` followed by digits.

The updated code changes the regular expression pattern to `"/v\d.+"` to match version directory names with a leading slash, and then removes the leading slash from the matched version directory names using `string replace`.

This fix ensures that the `_nvm_list` function correctly matches version directory names and produces the expected output.

**Changes:**

* Added a new local variable `installed_versions` to store the version directory names without the path
* Used `string replace` to remove the `$nvm_data/` prefix from each version directory name
* Updated the regular expression pattern to match only the version directory names